### PR TITLE
feat: キャンペーンモード - 不特定多数からインタビュー回答を収集

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -147,6 +147,8 @@ const TRANSLATIONS = {
     'shared.tag': '共有済',
 
     // Next steps
+    'sidebar.campaign': 'キャンペーンURLを発行',
+    'toast.campaignUrl': 'キャンペーンURLをコピーしました',
     'next.title': '次のステップ：コーディングエージェントで実装を開始',
     'next.desc': 'エクスポートした spec.json / PRD.md をコーディングエージェントに渡すだけで、実装を開始できます。',
     'next.badge': 'おすすめ',
@@ -282,6 +284,8 @@ const TRANSLATIONS = {
     'shared.tag': 'Shared',
 
     // Next steps
+    'sidebar.campaign': 'Create campaign URL',
+    'toast.campaignUrl': 'Campaign URL copied',
     'next.title': 'Next: Start building with a coding agent',
     'next.desc': 'Just hand the exported spec.json / PRD.md to your coding agent to start implementation.',
     'next.badge': 'Recommended',
@@ -417,6 +421,8 @@ const TRANSLATIONS = {
     'shared.tag': 'Compartida',
 
     // Next steps
+    'sidebar.campaign': 'Crear URL de campaña',
+    'toast.campaignUrl': 'URL de campaña copiada',
     'next.title': 'Siguiente: Comienza a construir con un agente de código',
     'next.desc': 'Solo pasa el spec.json / PRD.md exportado a tu agente de código para comenzar la implementación.',
     'next.badge': 'Recomendado',

--- a/public/index.html
+++ b/public/index.html
@@ -223,6 +223,9 @@
             <button class="btn btn-sm btn-secondary" style="width:100%;margin-top:12px" onclick="shareSession(currentSessionId)">
               <span data-i18n="sidebar.share">共有URLを発行</span>
             </button>
+            <button class="btn btn-sm btn-accent" style="width:100%;margin-top:8px" onclick="createCampaign(currentSessionId)">
+              <span data-i18n="sidebar.campaign">キャンペーンURLを発行</span>
+            </button>
           </div>
 
           <div class="interview-main">
@@ -373,7 +376,7 @@
                 <label data-i18n="shared.nameLabel">お名前（任意）</label>
                 <input type="text" id="shared-name" data-i18n="shared.namePlaceholder" placeholder="例：田中太郎">
               </div>
-              <button class="btn btn-primary btn-lg" onclick="startSharedInterview()" id="btn-shared-start">
+              <button class="btn btn-primary btn-lg" onclick="campaignToken ? startCampaignInterview() : startSharedInterview()" id="btn-shared-start">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
                 <span data-i18n="shared.start">インタビューを始める</span>
               </button>
@@ -392,13 +395,13 @@
             <div class="chat-input-area">
               <textarea id="shared-chat-input" data-i18n="interview.placeholder" placeholder="回答を入力…" rows="2"
                 onkeydown="handleSharedKeydown(event)"></textarea>
-              <button class="btn btn-primary" onclick="sendSharedMessage()" id="btn-shared-send">
+              <button class="btn btn-primary" onclick="campaignToken ? sendCampaignMessage() : sendSharedMessage()" id="btn-shared-send">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
               </button>
             </div>
             <div class="chat-hint" data-i18n="interview.hint">Shift + Enter で送信　・　Enter で改行</div>
             <div class="step-actions" id="shared-complete-actions" style="display:none">
-              <button class="btn btn-accent btn-lg" onclick="completeSharedInterview()">
+              <button class="btn btn-accent btn-lg" onclick="campaignToken ? completeCampaignInterview() : completeSharedInterview()">
                 <span data-i18n="shared.complete">インタビューを完了する →</span>
               </button>
             </div>
@@ -414,7 +417,7 @@
                 <label data-i18n="shared.feedbackLabel">フィードバック（任意）</label>
                 <textarea id="shared-feedback" data-i18n="shared.feedbackPlaceholder" placeholder="抽出内容への修正や追加コメントがあれば…" rows="3"></textarea>
               </div>
-              <button class="btn btn-primary btn-lg" onclick="submitSharedFeedback()" style="width:100%">
+              <button class="btn btn-primary btn-lg" onclick="campaignToken ? submitCampaignFeedback() : submitSharedFeedback()" style="width:100%">
                 <span data-i18n="shared.submit">送信して完了</span>
               </button>
             </div>


### PR DESCRIPTION
## 概要

1つのテーマに対して不特定多数の回答者からデプスインタビュー回答を収集するキャンペーンモードを追加。

## 背景

既存の共有機能（`/i/{token}`）は1セッション=1回答者で、同じセッションを共有する形式。
不特定多数からの意見収集には、回答者ごとに独立セッションが必要。

## 変更内容

### データモデル
- `campaigns` テーブル新設（id, theme, owner_session_id, share_token）
- `sessions` テーブルに `campaign_id` カラム追加

### バックエンド API
- `POST /api/sessions/:id/campaign` — キャンペーン作成
- `GET /api/campaigns/:token` — キャンペーン情報取得
- `POST /api/campaigns/:token/join` — 回答者として参加（独立セッション生成）
- `POST /api/campaigns/:token/sessions/:id/chat` — 回答者チャット
- `POST /api/campaigns/:token/sessions/:id/complete` — インタビュー完了・ファクト抽出
- `POST /api/campaigns/:token/sessions/:id/feedback` — フィードバック保存
- `GET /api/campaigns/:token/aggregate` — 全回答者のファクトを集約

### フロントエンド
- `/c/{token}` URL でキャンペーン回答ページを表示
- 各回答者がアクセスするたびに独立セッションを自動生成
- 既存の共有インタビュー UI を再利用（campaignToken で分岐）
- サイドバーに「キャンペーン URL を発行」ボタン追加
- 3 言語対応（JA/EN/ES）

### 共有モデル比較
| モード | URL | 用途 |
|---|---|---|
| 共有 | `/i/{token}` | 1 人の回答者とセッションを共有 |
| キャンペーン | `/c/{token}` | 不特定多数が各自独立してインタビューに回答 |

## テスト
- [x] キャンペーン作成 API 動作確認
- [x] キャンペーン参加・チャット・完了フロー動作確認
- [x] キャンペーン集約 API 動作確認
- [x] `/c/{token}` ページ表示確認
- [x] CI 全チェック通過（lint, format, test, build）
