### PR TITLE
fix: GitHub OAuth 修正 + エラーハンドラー + サービス設定改善

### DIFF
--- a/deepform.service
+++ b/deepform.service
@@ -11,6 +11,7 @@ ExecStart=/home/exedev/DeepForm/node_modules/.bin/tsx src/index.ts
 Restart=on-failure
 RestartSec=3
 Environment=NODE_ENV=production
+EnvironmentFile=/home/exedev/DeepForm/.env
 
 [Install]
 WantedBy=multi-user.target

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { bodyLimit } from 'hono/body-limit';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { authMiddleware } from './middleware/auth.js';
@@ -6,6 +7,15 @@ import { authRoutes } from './routes/auth.js';
 import { sessionRoutes } from './routes/sessions.js';
 
 const app = new Hono();
+
+// Global error handler
+app.onError((err, c) => {
+  console.error('Unhandled error:', err.message, err.stack);
+  if (err instanceof HTTPException) {
+    return c.json({ error: err.message }, err.status);
+  }
+  return c.json({ error: 'Internal Server Error' }, 500);
+});
 
 // Body size limit (equivalent to Express's express.json({ limit: '10mb' }))
 app.use('/api/*', bodyLimit({ maxSize: 10 * 1024 * 1024 }));

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -13,7 +13,7 @@ auth.use(
   githubAuth({
     client_id: process.env.GITHUB_CLIENT_ID,
     client_secret: process.env.GITHUB_CLIENT_SECRET,
-    scope: ['read:user'],
+    scope: ['read:user', 'user:email'],
     oauthApp: true,
   })
 );
@@ -21,7 +21,7 @@ auth.use(
 auth.get('/github', async (c) => {
   const githubUser = c.get('user-github');
   if (!githubUser || !githubUser.id || !githubUser.login) {
-    return c.json({ error: 'GitHub 認証に失敗しました' }, 401);
+    return c.json({ error: 'GitHub \u8a8d\u8a3c\u306b\u5931\u6557\u3057\u307e\u3057\u305f' }, 401);
   }
 
   // Upsert user in database


### PR DESCRIPTION
## 修正内容

- **GitHub OAuth**: scope に `user:email` を追加。`@hono/oauth-providers` が `/user/emails` API を呼ぶため必須。
- **エラーハンドラー**: Hono グローバルエラーハンドラーを追加。HTTPException を JSON レスポンスとして返す。
- **deepform.service**: 秘密情報を `EnvironmentFile=/home/exedev/DeepForm/.env` から読み込む方式に変更（ハードコード防止）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented global error handling system that returns consistent JSON error responses for improved debugging and troubleshooting
  * Extended GitHub authentication to request additional user email permissions

* **Chores**
  * Updated application startup process and runtime configuration
  * Added automatic environment variable loading from configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->