### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delete-workflow-history.yml
+++ b/.github/workflows/delete-workflow-history.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   delete-history:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/susumutomita/DeepForm/security/code-scanning/1](https://github.com/susumutomita/DeepForm/security/code-scanning/1)

To fix the problem, explicitly declare a `permissions` block in the workflow so that the `GITHUB_TOKEN` has only the scopes needed. This can be done at the root of the workflow (applies to all jobs) or on the `delete-history` job itself. Since there is only one job and it performs a destructive action (`gh api -X DELETE repos/.../actions/runs/{}`), we should specify the minimal permissions it needs: `actions: write` to delete workflow runs, and `contents: read` to match a conservative baseline (reading repo metadata is commonly required and is equivalent to read-only defaults). No other scopes appear necessary from the shown code.

The single best fix without changing functionality is to add a `permissions` block at the top level of `.github/workflows/delete-workflow-history.yml`, between the `on:` block and `jobs:`. This will apply to `delete-history` and any future jobs unless they override it. Concretely, in `.github/workflows/delete-workflow-history.yml`, after line 10 (end of the `on.workflow_dispatch.inputs` section) and before line 11 (`jobs:`), insert:

```yaml
permissions:
  actions: write
  contents: read
```

No new methods, imports, or external libraries are needed; this is purely a YAML configuration change in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
