### PR TITLE
feat: Deploy to exe.dev ボタン (#31)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -333,6 +333,17 @@
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
                   <span data-i18n="spec.exportMd">PRD.md をコピー</span>
                 </button>
+                <button class="btn btn-deploy btn-lg" onclick="deployToExeDev()">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+                  <span data-i18n="spec.deploy">Deploy to exe.dev</span>
+                </button>
+              </div>
+              <div id="exedev-link-container" class="exedev-link-container hidden">
+                <p>Spec をコピーしました。exe.dev でプロジェクトを作成してください。</p>
+                <a href="https://exe.dev" target="_blank" rel="noopener" class="btn btn-accent btn-lg">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                  exe.dev を開く
+                </a>
               </div>
 
               <!-- Next Steps -->

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -98,6 +98,11 @@ export function runSpec(sessionId: string): Promise<SpecData> {
   return post(`/api/sessions/${sessionId}/spec`);
 }
 
+// Spec Export
+export function getSpecExport(sessionId: string): Promise<{ theme: string; spec: unknown; prdMarkdown: string | null; exportedAt: string }> {
+  return request(`/api/sessions/${sessionId}/spec-export`);
+}
+
 // Share
 export function shareSession(sessionId: string): Promise<{ shareToken: string }> {
   return post(`/api/sessions/${sessionId}/share`);

--- a/frontend/src/interview.ts
+++ b/frontend/src/interview.ts
@@ -219,6 +219,25 @@ export async function exportPRDMarkdown(): Promise<void> {
   }
 }
 
+// --- Deploy to exe.dev ---
+export async function doDeployToExeDev(): Promise<void> {
+  if (!currentSessionId) return;
+  try {
+    const data = await api.getSpecExport(currentSessionId);
+    const specJson = JSON.stringify(data.spec, null, 2);
+    await navigator.clipboard.writeText(specJson);
+    showToast('Spec をクリップボードにコピーしました。exe.dev で新しいプロジェクトを作成してください');
+
+    // Show the exe.dev link section
+    const linkContainer = document.getElementById('exedev-link-container');
+    if (linkContainer) {
+      linkContainer.classList.remove('hidden');
+    }
+  } catch (e: any) {
+    showToast(e.message, true);
+  }
+}
+
 // --- Renderers ---
 function renderFacts(facts: Fact[]): void {
   const container = document.getElementById('facts-container');

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,7 +6,7 @@ import { loadSessions, doToggleVisibility, doShareSession, doCreateCampaign } fr
 import {
   showHome, openSession, sendMessage, handleChatKeydown,
   doRunAnalysis, doRunHypotheses, doRunPRD, doRunSpec,
-  exportSpecJSON, exportPRDMarkdown, activateStep,
+  exportSpecJSON, exportPRDMarkdown, doDeployToExeDev, activateStep,
 } from './interview';
 import {
   initSharedInterview, initCampaignInterview,
@@ -40,6 +40,7 @@ w.runPRD = doRunPRD;
 w.runSpec = doRunSpec;
 w.exportSpecJSON = exportSpecJSON;
 w.exportPRDMarkdown = exportPRDMarkdown;
+w.deployToExeDev = doDeployToExeDev;
 w.activateStep = activateStep;
 w.logout = doLogout;
 w.setLang = setLang;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1119,6 +1119,36 @@ a:hover { color: var(--primary-hover); }
   flex-wrap: wrap;
 }
 
+/* === Deploy to exe.dev === */
+.btn-deploy {
+  background: var(--accent-cyan);
+  color: #fff;
+  border: none;
+}
+.btn-deploy:hover:not(:disabled) {
+  background: #4e7d77;
+}
+
+.exedev-link-container {
+  margin-top: 16px;
+  padding: 20px;
+  background: rgba(94,141,135,0.06);
+  border: 1px solid rgba(94,141,135,0.15);
+  border-radius: var(--radius);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.exedev-link-container p {
+  font-size: 14px;
+  color: var(--text-dim);
+}
+.exedev-link-container.hidden {
+  display: none;
+}
+
 /* === PRD Table === */
 .prd-section table {
   width: 100%;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -245,6 +245,7 @@ export interface DeepFormWindow extends Window {
   runSpec: () => Promise<void>;
   exportSpecJSON: () => void;
   exportPRDMarkdown: () => void;
+  deployToExeDev: () => Promise<void>;
 
   // Shared / Campaign
   startSharedInterview: () => Promise<void>;


### PR DESCRIPTION
## Summary
- spec 生成後に「Deploy to exe.dev」ボタンを追加
- spec.json をクリップボードにコピー + exe.dev リンク表示
- `GET /api/sessions/:id/spec-export` エンドポイント追加
- spec-export のテスト 6 件追加（認証・認可・バリデーション）

## Changes
- **Backend**: `src/routes/sessions.ts` に spec-export エンドポイント追加（owner or public アクセス制御）
- **Frontend**: `interview.ts` に `doDeployToExeDev()` 関数追加、`api.ts` に `getSpecExport()` 追加
- **HTML**: spec ステップに Deploy ボタンと exe.dev リンクコンテナ追加
- **CSS**: `.btn-deploy` と `.exedev-link-container` スタイル追加
- **Types**: `DeepFormWindow` に `deployToExeDev` 追加
- **Tests**: spec-export エンドポイントの 6 テスト追加（自分のセッション、公開セッション、他人の非公開、404、spec 未生成、未認証）

## Test plan
- [x] `bun run test` で全 109 テスト通過
- [x] `bun run lint` 通過（既存 warning のみ）
- [x] `bun run typecheck` 通過

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)