### PR TITLE
feat: フィードバックフォーム (Issue 29)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -207,6 +207,7 @@
           <p data-i18n="footer.tagline">DeepForm — From vague idea → deployable spec.</p>
           <p class="footer-sub" data-i18n="footer.credit">Built with Claude AI × exe.dev</p>
           <div class="footer-legal">
+            <a href="#" onclick="openFeedbackModal(); return false;" data-i18n="feedback.link">フィードバック</a>
             <a href="#" onclick="openPolicy('privacy'); return false;" data-i18n="legal.privacy">プライバシーポリシー</a>
             <a href="#" onclick="openPolicy('terms'); return false;" data-i18n="legal.terms">利用規約</a>
             <a href="#" onclick="openPolicy('security'); return false;" data-i18n="legal.security">セキュリティポリシー</a>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,3 +148,8 @@ export function completeCampaign(token: string, sessionId: string): Promise<Fact
 export function feedbackCampaign(token: string, sessionId: string, feedback: string | null): Promise<void> {
   return post(`/api/campaigns/${token}/sessions/${sessionId}/feedback`, { feedback });
 }
+
+// App feedback
+export function submitAppFeedback(type: string, message: string, page?: string): Promise<{ ok: boolean }> {
+  return post('/api/feedback', { type, message, page });
+}

--- a/frontend/src/feedback.ts
+++ b/frontend/src/feedback.ts
@@ -1,0 +1,132 @@
+// === DeepForm Feedback Modal ===
+import { t } from './i18n';
+import { showToast } from './ui';
+import * as api from './api';
+
+let feedbackModal: HTMLElement | null = null;
+
+function createModal(): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'feedback-overlay';
+  overlay.id = 'feedback-modal';
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeFeedbackModal();
+  });
+
+  const card = document.createElement('div');
+  card.className = 'feedback-card';
+
+  // Title
+  const title = document.createElement('h2');
+  title.className = 'feedback-title';
+  title.textContent = t('feedback.title');
+  card.appendChild(title);
+
+  // Type select
+  const typeLabel = document.createElement('label');
+  typeLabel.className = 'feedback-label';
+  typeLabel.setAttribute('for', 'feedback-type');
+  typeLabel.textContent = t('feedback.typeLabel');
+  card.appendChild(typeLabel);
+
+  const typeSelect = document.createElement('select');
+  typeSelect.id = 'feedback-type';
+  typeSelect.className = 'feedback-select';
+
+  const types: Array<{ value: string; labelKey: string }> = [
+    { value: 'bug', labelKey: 'feedback.typeBug' },
+    { value: 'feature', labelKey: 'feedback.typeFeature' },
+    { value: 'other', labelKey: 'feedback.typeOther' },
+  ];
+  for (const { value, labelKey } of types) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = t(labelKey);
+    typeSelect.appendChild(option);
+  }
+  card.appendChild(typeSelect);
+
+  // Message textarea
+  const msgLabel = document.createElement('label');
+  msgLabel.className = 'feedback-label';
+  msgLabel.setAttribute('for', 'feedback-message');
+  msgLabel.textContent = t('feedback.messageLabel');
+  card.appendChild(msgLabel);
+
+  const msgArea = document.createElement('textarea');
+  msgArea.id = 'feedback-message';
+  msgArea.className = 'feedback-textarea';
+  msgArea.placeholder = t('feedback.messagePlaceholder');
+  msgArea.rows = 5;
+  msgArea.maxLength = 5000;
+  card.appendChild(msgArea);
+
+  // Buttons
+  const btnRow = document.createElement('div');
+  btnRow.className = 'feedback-buttons';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'btn btn-secondary';
+  cancelBtn.textContent = t('feedback.cancel');
+  cancelBtn.addEventListener('click', closeFeedbackModal);
+  btnRow.appendChild(cancelBtn);
+
+  const submitBtn = document.createElement('button');
+  submitBtn.className = 'btn btn-primary';
+  submitBtn.id = 'feedback-submit';
+  submitBtn.textContent = t('feedback.submit');
+  submitBtn.addEventListener('click', handleSubmit);
+  btnRow.appendChild(submitBtn);
+
+  card.appendChild(btnRow);
+  overlay.appendChild(card);
+
+  return overlay;
+}
+
+async function handleSubmit(): Promise<void> {
+  const typeEl = document.getElementById('feedback-type') as HTMLSelectElement | null;
+  const msgEl = document.getElementById('feedback-message') as HTMLTextAreaElement | null;
+  const submitBtn = document.getElementById('feedback-submit') as HTMLButtonElement | null;
+  if (!typeEl || !msgEl) return;
+
+  const type = typeEl.value;
+  const message = msgEl.value.trim();
+  if (!message) {
+    showToast(t('feedback.error'), true);
+    return;
+  }
+
+  if (submitBtn) submitBtn.disabled = true;
+
+  try {
+    await api.submitAppFeedback(type, message, window.location.pathname);
+    showToast(t('feedback.success'));
+    closeFeedbackModal();
+  } catch (e: any) {
+    const msg = e.message || '';
+    if (msg.includes('60秒') || msg.includes('429')) {
+      showToast(t('feedback.rateLimit'), true);
+    } else {
+      showToast(t('feedback.error'), true);
+    }
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
+  }
+}
+
+export function openFeedbackModal(): void {
+  closeFeedbackModal();
+  feedbackModal = createModal();
+  document.body.appendChild(feedbackModal);
+  // Focus textarea
+  const msg = document.getElementById('feedback-message') as HTMLTextAreaElement | null;
+  if (msg) msg.focus();
+}
+
+export function closeFeedbackModal(): void {
+  if (feedbackModal) {
+    feedbackModal.remove();
+    feedbackModal = null;
+  }
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -144,6 +144,19 @@ const ja: TranslationMap = {
   'legal.privacy': 'プライバシーポリシー',
   'legal.terms': '利用規約',
   'legal.security': 'セキュリティポリシー',
+  'feedback.link': 'フィードバック',
+  'feedback.title': 'フィードバックを送る',
+  'feedback.typeLabel': '種別',
+  'feedback.typeBug': 'バグ報告',
+  'feedback.typeFeature': '機能要望',
+  'feedback.typeOther': 'その他',
+  'feedback.messageLabel': 'メッセージ',
+  'feedback.messagePlaceholder': 'ご意見・ご要望をお聞かせください…',
+  'feedback.submit': '送信',
+  'feedback.cancel': 'キャンセル',
+  'feedback.success': 'フィードバックを送信しました。ありがとうございます！',
+  'feedback.error': 'フィードバックの送信に失敗しました',
+  'feedback.rateLimit': '送信は60秒に1回までです',
 };
 
 const en: TranslationMap = {
@@ -288,6 +301,19 @@ const en: TranslationMap = {
   'legal.privacy': 'Privacy Policy',
   'legal.terms': 'Terms of Service',
   'legal.security': 'Security Policy',
+  'feedback.link': 'Feedback',
+  'feedback.title': 'Send Feedback',
+  'feedback.typeLabel': 'Type',
+  'feedback.typeBug': 'Bug Report',
+  'feedback.typeFeature': 'Feature Request',
+  'feedback.typeOther': 'Other',
+  'feedback.messageLabel': 'Message',
+  'feedback.messagePlaceholder': 'Tell us what you think…',
+  'feedback.submit': 'Submit',
+  'feedback.cancel': 'Cancel',
+  'feedback.success': 'Feedback sent. Thank you!',
+  'feedback.error': 'Failed to send feedback',
+  'feedback.rateLimit': 'Please wait 60 seconds between submissions',
 };
 
 const es: TranslationMap = {
@@ -432,6 +458,19 @@ const es: TranslationMap = {
   'legal.privacy': 'Política de Privacidad',
   'legal.terms': 'Términos de Servicio',
   'legal.security': 'Política de Seguridad',
+  'feedback.link': 'Comentarios',
+  'feedback.title': 'Enviar comentarios',
+  'feedback.typeLabel': 'Tipo',
+  'feedback.typeBug': 'Reporte de error',
+  'feedback.typeFeature': 'Solicitud de función',
+  'feedback.typeOther': 'Otro',
+  'feedback.messageLabel': 'Mensaje',
+  'feedback.messagePlaceholder': 'Cuéntanos tu opinión…',
+  'feedback.submit': 'Enviar',
+  'feedback.cancel': 'Cancelar',
+  'feedback.success': 'Comentario enviado. ¡Gracias!',
+  'feedback.error': 'Error al enviar comentarios',
+  'feedback.rateLimit': 'Espera 60 segundos entre envíos',
 };
 
 const TRANSLATIONS: Record<string, TranslationMap> = { ja, en, es };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -16,6 +16,7 @@ import {
 } from './shared';
 import { showToast, toggleTheme, initTheme } from './ui';
 import { openPolicy, closeModal } from './modal';
+import { openFeedbackModal, closeFeedbackModal } from './feedback';
 import { t } from './i18n';
 import { renderPrivacyPolicy } from './pages/privacy';
 import { renderTerms } from './pages/terms';
@@ -97,6 +98,8 @@ w.startNewSession = async () => {
 w.toggleTheme = toggleTheme;
 w.openPolicy = openPolicy;
 w.closeModal = closeModal;
+w.openFeedbackModal = openFeedbackModal;
+w.closeFeedbackModal = closeFeedbackModal;
 
 w.toggleMobileMenu = () => {
   const nav = document.getElementById('header-nav');

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1637,6 +1637,74 @@ a:hover { color: var(--primary-hover); }
   .modal-content { max-height: 90vh; margin: 8px; border-radius: var(--radius); }
 }
 
+/* === Feedback Modal === */
+.feedback-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.feedback-card {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-lg);
+  max-width: 500px;
+  width: 100%;
+  padding: 28px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+}
+.feedback-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0 0 20px;
+}
+.feedback-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+  margin-top: 14px;
+}
+.feedback-select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+.feedback-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+  resize: vertical;
+  font-family: inherit;
+}
+.feedback-textarea:focus,
+.feedback-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(129, 162, 190, 0.2);
+}
+.feedback-buttons {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+@media (max-width: 768px) {
+  .feedback-card { margin: 8px; padding: 20px; }
+}
+
 /* === Dark Mode === */
 /* Manual toggle via data-theme attribute */
 [data-theme="dark"] {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -269,4 +269,8 @@ export interface DeepFormWindow extends Window {
   openPolicy: (key: string) => void;
   closeModal: () => void;
   activateStep: (stepName: string) => void;
+
+  // Feedback
+  openFeedbackModal: () => void;
+  closeFeedbackModal: () => void;
 }

--- a/src/__tests__/helpers/test-db.ts
+++ b/src/__tests__/helpers/test-db.ts
@@ -53,6 +53,15 @@ export const FULL_SCHEMA = `
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (owner_session_id) REFERENCES sessions(id)
   );
+  CREATE TABLE IF NOT EXISTS feedback (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT REFERENCES users(id),
+    type TEXT NOT NULL,
+    message TEXT NOT NULL,
+    page TEXT,
+    ip_address TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
 `;
 
 export function createTestDb() {

--- a/src/__tests__/routes/feedback.test.ts
+++ b/src/__tests__/routes/feedback.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock static file serving to avoid filesystem access in tests
+vi.mock("@hono/node-server/serve-static", () => ({
+  serveStatic: () => async (_c: any, next: any) => await next(),
+}));
+
+// node:sqlite でテスト用 DB を作成（ネイティブバイナリ不要）
+vi.mock("../../db.ts", async () => {
+  const { createTestDb } = await import("../helpers/test-db.ts");
+  return { db: createTestDb() };
+});
+
+// Mock LLM (feedbackルートでは使わないが、app.ts の依存で必要)
+vi.mock("../../llm.ts", () => ({
+  callClaude: vi.fn().mockResolvedValue({
+    content: [{ type: "text", text: "モック LLM レスポンス" }],
+  }),
+  extractText: vi.fn().mockReturnValue("モック LLM レスポンス"),
+}));
+
+import { app } from "../../app.ts";
+import { db } from "../../db.ts";
+import { clearRateLimitMap } from "../../routes/feedback.ts";
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+const TEST_EXE_USER_ID = "exe-fb-001";
+const TEST_EMAIL = "feedback-test@example.com";
+
+async function authedRequest(path: string, options: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(options.headers);
+  headers.set("x-exedev-userid", TEST_EXE_USER_ID);
+  headers.set("x-exedev-email", TEST_EMAIL);
+  return await app.request(path, { ...options, headers });
+}
+
+async function anonRequest(path: string, options: RequestInit = {}): Promise<Response> {
+  return await app.request(path, options);
+}
+
+function postFeedback(
+  body: Record<string, unknown>,
+  options: { authed?: boolean; headers?: Record<string, string> } = {},
+): Promise<Response> {
+  const reqOptions: RequestInit = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+    body: JSON.stringify(body),
+  };
+  if (options.authed) {
+    return authedRequest("/api/feedback", reqOptions);
+  }
+  return anonRequest("/api/feedback", reqOptions);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: clean tables using parameterized DELETE (not exec)
+// ---------------------------------------------------------------------------
+function cleanTables(): void {
+  db.prepare("DELETE FROM feedback").run();
+  db.prepare("DELETE FROM users").run();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("フィードバック API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearRateLimitMap();
+    cleanTables();
+  });
+
+  // -------------------------------------------------------------------------
+  // 正常系
+  // -------------------------------------------------------------------------
+  describe("POST /api/feedback — 正常送信", () => {
+    it("未認証ユーザーがフィードバックを送信できること", async () => {
+      // Given: 未認証ユーザー
+      // When: フィードバックを送信
+      const res = await postFeedback({
+        type: "bug",
+        message: "ボタンが動きません",
+        page: "/session/abc",
+      });
+
+      // Then: 201で保存される
+      expect(res.status).toBe(201);
+      const data = (await res.json()) as { ok: boolean };
+      expect(data.ok).toBe(true);
+
+      // DB に保存されていることを確認
+      const row = db.prepare("SELECT * FROM feedback").get() as any;
+      expect(row.type).toBe("bug");
+      expect(row.message).toBe("ボタンが動きません");
+      expect(row.page).toBe("/session/abc");
+      expect(row.user_id).toBeNull();
+    });
+
+    it("認証済みユーザーがフィードバックを送信すると user_id が記録されること", async () => {
+      // Given: 認証済みユーザー
+      // When: フィードバックを送信
+      const res = await postFeedback({ type: "feature", message: "ダークモードが欲しい" }, { authed: true });
+
+      // Then: 201で user_id 付きで保存される
+      expect(res.status).toBe(201);
+      const row = db.prepare("SELECT * FROM feedback").get() as any;
+      expect(row.type).toBe("feature");
+      expect(row.message).toBe("ダークモードが欲しい");
+      expect(row.user_id).toBeTruthy();
+    });
+
+    it("type が 'other' でも正常に送信できること", async () => {
+      const res = await postFeedback({
+        type: "other",
+        message: "その他のフィードバック",
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it("page が省略された場合 null で保存されること", async () => {
+      const res = await postFeedback({
+        type: "bug",
+        message: "ページ指定なし",
+      });
+      expect(res.status).toBe(201);
+      const row = db.prepare("SELECT * FROM feedback").get() as any;
+      expect(row.page).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // バリデーションエラー
+  // -------------------------------------------------------------------------
+  describe("POST /api/feedback — バリデーションエラー", () => {
+    it("メッセージが空の場合 400 を返すこと", async () => {
+      const res = await postFeedback({
+        type: "bug",
+        message: "",
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain("メッセージを入力してください");
+    });
+
+    it("メッセージが5001文字を超える場合 400 を返すこと", async () => {
+      const longMessage = "あ".repeat(5001);
+      const res = await postFeedback({
+        type: "bug",
+        message: longMessage,
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as { error: string };
+      expect(data.error).toContain("5000文字以内");
+    });
+
+    it("type が不正な場合 400 を返すこと", async () => {
+      const res = await postFeedback({
+        type: "invalid",
+        message: "テスト",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("type が省略された場合 400 を返すこと", async () => {
+      const res = await postFeedback({
+        message: "テスト",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("message が省略された場合 400 を返すこと", async () => {
+      const res = await postFeedback({
+        type: "bug",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("不正な JSON の場合 400 を返すこと", async () => {
+      const res = await anonRequest("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // レート制限
+  // -------------------------------------------------------------------------
+  describe("POST /api/feedback — レート制限", () => {
+    it("同一IPから60秒以内に2回送信すると429を返すこと", async () => {
+      // Given: 1回目の送信が成功
+      const res1 = await postFeedback(
+        { type: "bug", message: "1回目" },
+        { headers: { "x-forwarded-for": "192.168.1.100" } },
+      );
+      expect(res1.status).toBe(201);
+
+      // When: 同一IPから2回目を送信
+      const res2 = await postFeedback(
+        { type: "bug", message: "2回目" },
+        { headers: { "x-forwarded-for": "192.168.1.100" } },
+      );
+
+      // Then: レート制限で拒否
+      expect(res2.status).toBe(429);
+      const data = (await res2.json()) as { error: string };
+      expect(data.error).toContain("60秒");
+    });
+
+    it("異なるIPからの送信はレート制限されないこと", async () => {
+      const res1 = await postFeedback({ type: "bug", message: "IP A" }, { headers: { "x-forwarded-for": "10.0.0.1" } });
+      expect(res1.status).toBe(201);
+
+      const res2 = await postFeedback({ type: "bug", message: "IP B" }, { headers: { "x-forwarded-for": "10.0.0.2" } });
+      expect(res2.status).toBe(201);
+    });
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { bodyLimit } from "hono/body-limit";
 import { HTTPException } from "hono/http-exception";
 import { authMiddleware } from "./middleware/auth.ts";
 import { authRoutes } from "./routes/auth.ts";
+import { feedbackRoutes } from "./routes/feedback.ts";
 import { sessionRoutes } from "./routes/sessions.ts";
 
 const app = new Hono();
@@ -35,6 +36,9 @@ app.route("/api/auth", authRoutes);
 
 // Session routes
 app.route("/api", sessionRoutes);
+
+// Feedback routes
+app.route("/api/feedback", feedbackRoutes);
 
 // Static file serving
 app.use("/*", serveStatic({ root: staticRoot }));

--- a/src/db.ts
+++ b/src/db.ts
@@ -99,6 +99,19 @@ try {
 db.prepare("UPDATE users SET exe_user_id = id WHERE exe_user_id IS NULL").run();
 db.prepare("UPDATE users SET email = 'unknown@example.com' WHERE email IS NULL").run();
 
+// Migration: feedback table
+db.exec(`
+  CREATE TABLE IF NOT EXISTS feedback (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT REFERENCES users(id),
+    type TEXT NOT NULL,
+    message TEXT NOT NULL,
+    page TEXT,
+    ip_address TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`);
+
 // Ensure unique index on exe_user_id for consistency with CREATE TABLE schema
 try {
   db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_exe_user_id ON users(exe_user_id)").run();

--- a/src/routes/feedback.ts
+++ b/src/routes/feedback.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import { ZodError } from "zod";
+import { db } from "../db.ts";
+import type { User } from "../types.ts";
+import { appFeedbackSchema } from "../validation.ts";
+
+type AppEnv = { Variables: { user: User | null } };
+const feedbackRoutes = new Hono<AppEnv>();
+
+// ---------------------------------------------------------------------------
+// In-memory rate limiting: 1 request per IP per 60 seconds
+// ---------------------------------------------------------------------------
+const rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const lastRequest = rateLimitMap.get(ip);
+  if (lastRequest && now - lastRequest < RATE_LIMIT_WINDOW_MS) {
+    return true;
+  }
+  rateLimitMap.set(ip, now);
+  return false;
+}
+
+/** テスト用: レートリミットマップをクリアする */
+export function clearRateLimitMap(): void {
+  rateLimitMap.clear();
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback — Submit app feedback (auth optional)
+// ---------------------------------------------------------------------------
+feedbackRoutes.post("/", async (c) => {
+  try {
+    // Rate limit by IP
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() || c.req.header("x-real-ip") || "unknown";
+    if (isRateLimited(ip)) {
+      return c.json({ error: "送信は60秒に1回までです。しばらく待ってから再度お試しください。" }, 429);
+    }
+
+    const body = await c.req.json();
+    const { type, message, page } = appFeedbackSchema.parse(body);
+
+    // Auth is optional — attach user_id if logged in
+    const user = c.get("user");
+    const userId = user?.id ?? null;
+
+    db.prepare("INSERT INTO feedback (user_id, type, message, page, ip_address) VALUES (?, ?, ?, ?, ?)").run(
+      userId,
+      type,
+      message,
+      page ?? null,
+      ip,
+    );
+
+    return c.json({ ok: true }, 201);
+  } catch (e) {
+    if (e instanceof SyntaxError) return c.json({ error: "Invalid JSON" }, 400);
+    if (e instanceof ZodError) {
+      const msg = e.issues.map((i) => i.message).join(", ");
+      return c.json({ error: msg }, 400);
+    }
+    console.error("Feedback submission error:", e);
+    return c.json({ error: "フィードバックの送信に失敗しました" }, 500);
+  }
+});
+
+export { feedbackRoutes };

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -19,3 +19,9 @@ export const respondentNameSchema = z.object({
 export const feedbackSchema = z.object({
   feedback: z.string().max(5000).optional().nullable(),
 });
+
+export const appFeedbackSchema = z.object({
+  type: z.enum(["bug", "feature", "other"]),
+  message: z.string().min(1, "メッセージを入力してください").max(5000, "メッセージは5000文字以内で入力してください"),
+  page: z.string().max(200).optional(),
+});


### PR DESCRIPTION
## Summary
- feedback テーブル + POST /api/feedback エンドポイント追加
- フィードバックモーダル UI（バグ / 機能要望 / その他）
- レート制限（60秒/1件）+ Zod バリデーション
- BDD テスト追加（12件）

## Test plan
- [x] `bun run test` で全テスト通過（115件）
- [x] `bun run lint` 通過（新規ファイルにエラー/警告なし）
- [x] `bun run typecheck` 通過（新規エラーなし）

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)