### PR TITLE
fix: GitHub OAuth callback URL の X-Forwarded-Host 対応

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -16,8 +16,10 @@ const SESSION_MAX_AGE_DAYS = 30;
 auth.get("/github", (c) => {
   const state = crypto.randomUUID();
   const proto = c.req.header("x-forwarded-proto") || "http";
-  const host = c.req.header("host") || "localhost:3000";
-  const callbackUrl = `${proto}://${host}/api/auth/github/callback`;
+  const host = c.req.header("x-forwarded-host") || c.req.header("host") || "localhost:8000";
+  // Strip port for standard HTTPS (GitHub callback URL must match exactly)
+  const cleanHost = proto === "https" ? host.replace(/:443$/, "") : host.replace(/:80$/, "");
+  const callbackUrl = `${proto}://${cleanHost}/api/auth/github/callback`;
 
   const params = new URLSearchParams({
     client_id: GITHUB_CLIENT_ID,


### PR DESCRIPTION
## 概要

GitHub OAuth の redirect_uri が GitHub App に登録された callback URL と一致せずログインできない問題を修正。

## 原因

exe.dev プロキシ経由のリクエストで `Host` ヘッダーにポートが含まれる場合があり、生成される callback URL が GitHub App の登録 URL と不一致になっていた。

## 修正内容

- `X-Forwarded-Host` ヘッダーを `Host` より優先して使用
- HTTPS:443 / HTTP:80 の標準ポートを除去


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub OAuth authentication callback URL resolution to properly support reverse proxy and multi-host deployment environments for improved login reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->