### PR TITLE
chore: Makefile に clean / build ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,21 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  install         Install dependencies (backend + frontend)"
+	@echo "  clean           Remove build artifacts"
+	@echo "  build           Build frontend (Vite)"
+	@echo "  start           Install, build, and start server"
+	@echo "  dev             Start dev server (hot reload)"
+	@echo "  lint            Run Biome linter"
+	@echo "  lint_text       Run textlint"
+	@echo "  typecheck       Run TypeScript type check"
+	@echo "  test            Run tests"
+	@echo "  before-commit   Run lint + lint_text + typecheck + test"
+
 .PHONY: install
 install:
 	bun install


### PR DESCRIPTION
## 概要

古いビルド成果物（`public/` 内のレガシーファイル）が残っていると、最新の GitHub OAuth 認証が反映されず exe.dev 時代の UI が表示される問題を解消する。

## 変更内容

- `make clean`: `public_dist/`、`frontend/dist/`、`public/` 内の旧ビルドファイルを削除
- `make build`: frontend の Vite ビルドを実行
- `make start`: `install` → `build` → サーバー起動に変更（常に最新ビルドで起動）
- `make install`: frontend の依存も一緒にインストール

## テスト

- lint / typecheck / test すべて通過済み（158 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline with new development infrastructure targets for linting, type checking, and testing.
  * Added dedicated development mode and pre-commit validation steps to streamline the development workflow and improve code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->