### PR TITLE
fix: CI ワークフローに pull_request トリガーを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
 
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要

fork からの PR で `ci` ワークフローが実行されない問題を修正。

## 原因

`ci.yml` のトリガーが `on: push` のみで `pull_request` がなかった。fork からの PR は fork 側で push イベントが発火するため、本リポジトリの CI が実行されなかった。

## 変更内容

- `push` トリガーを `branches: [main]` に限定（全ブランチ push での重複実行を防止）
- `pull_request` トリガーを追加（`branches: [main]` 向け）
- `e2e.yml` と同じトリガー構成に統一

## テスト

- lint / typecheck / test すべて通過済み（171 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous Integration workflow now automatically triggers on push and pull request events to the main branch, in addition to manual activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->