### PR TITLE
feat: アナリティクス改善 — UTM 追跡 + API 除外 + 5分重複排除

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -176,4 +176,15 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_page_views_path ON page_views(path);
 `);
 
+// Migration: add UTM columns to page_views
+try {
+  db.exec(`
+    ALTER TABLE page_views ADD COLUMN utm_source TEXT;
+    ALTER TABLE page_views ADD COLUMN utm_medium TEXT;
+    ALTER TABLE page_views ADD COLUMN utm_campaign TEXT;
+  `);
+} catch {
+  // Columns already exist
+}
+
 export { db };

--- a/src/middleware/analytics.ts
+++ b/src/middleware/analytics.ts
@@ -3,14 +3,29 @@ import { createMiddleware } from "hono/factory";
 import { db } from "../db.ts";
 
 const STATIC_EXTENSIONS = /\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$/;
+const API_PREFIX = /^\/api\//;
+
+// In-memory dedup: fingerprint+path -> last timestamp
+const recentHits = new Map<string, number>();
+const DEDUP_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+// Cleanup old entries periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, ts] of recentHits) {
+    if (now - ts > DEDUP_WINDOW_MS) recentHits.delete(key);
+  }
+}, 60_000);
 
 export const analyticsMiddleware = createMiddleware(async (c, next) => {
   await next();
 
-  const path = new URL(c.req.url).pathname;
+  const url = new URL(c.req.url);
+  const path = url.pathname;
 
-  // Skip static assets
+  // Skip static assets and API calls
   if (STATIC_EXTENSIONS.test(path)) return;
+  if (API_PREFIX.test(path)) return;
 
   try {
     const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() || c.req.header("x-real-ip") || "unknown";
@@ -19,10 +34,34 @@ export const analyticsMiddleware = createMiddleware(async (c, next) => {
     const user = c.get("user") as { id: string } | null | undefined;
     const fingerprint = crypto.createHash("sha256").update(`${ip}:${ua}`).digest("hex").substring(0, 12);
 
+    // Dedup: skip if same fingerprint+path within 5 minutes
+    const dedupKey = `${fingerprint}:${path}`;
+    const now = Date.now();
+    const lastHit = recentHits.get(dedupKey);
+    if (lastHit && now - lastHit < DEDUP_WINDOW_MS) return;
+    recentHits.set(dedupKey, now);
+
+    // Extract UTM parameters
+    const utmSource = url.searchParams.get("utm_source") || null;
+    const utmMedium = url.searchParams.get("utm_medium") || null;
+    const utmCampaign = url.searchParams.get("utm_campaign") || null;
+
     db.prepare(
-      `INSERT INTO page_views (path, method, status_code, referer, user_agent, ip_address, user_id, session_fingerprint, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
-    ).run(path, c.req.method, c.res.status, referer, ua, ip, user?.id || null, fingerprint);
+      `INSERT INTO page_views (path, method, status_code, referer, user_agent, ip_address, user_id, session_fingerprint, utm_source, utm_medium, utm_campaign, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    ).run(
+      path,
+      c.req.method,
+      c.res.status,
+      referer,
+      ua,
+      ip,
+      user?.id || null,
+      fingerprint,
+      utmSource,
+      utmMedium,
+      utmCampaign,
+    );
   } catch (e) {
     console.error("Analytics error:", e);
   }

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -62,6 +62,15 @@ analyticsRoutes.get("/stats", (c) => {
     )
     .all();
 
+  // UTM sources
+  const utmSources = db
+    .prepare(
+      `SELECT utm_source, utm_medium, utm_campaign, COUNT(*) as views, COUNT(DISTINCT session_fingerprint) as visitors
+     FROM page_views WHERE utm_source IS NOT NULL AND created_at >= ${since}
+     GROUP BY utm_source, utm_medium, utm_campaign ORDER BY visitors DESC LIMIT 20`,
+    )
+    .all();
+
   // Recent visitors (unique fingerprints)
   const recentVisitors = db
     .prepare(
@@ -79,6 +88,7 @@ analyticsRoutes.get("/stats", (c) => {
     viewsByDay,
     topPages,
     topReferers,
+    utmSources,
     recentVisitors,
   });
 });


### PR DESCRIPTION
## 概要

アクセス解析の精度を改善。リロードやAPIコールで水増しされていたビュー数を正確にし、流入元を追跡可能にする。

## 変更内容

### API パス除外
- `/api/*` へのリクエストはカウントしない（ページビューのみ記録）
- 1ページ表示で3件カウントされていた問題を解消

### 5分重複排除
- 同一フィンガープリント+パスの5分以内の重複リクエストを無視
- リロード連打でビュー数が膨れる問題を解消
- インメモリ Map で高速判定、1分ごとに古いエントリをクリーンアップ

### UTM パラメータ追跡
- `utm_source`, `utm_medium`, `utm_campaign` を記録
- Twitter は referer を送らないため、UTM で流入元を追跡
- `/api/admin/analytics/stats` に `utmSources` を追加

### 使い方
Twitter に貼る URL:
```
https://deepform.exe.xyz:8000/?utm_source=twitter&utm_medium=social&utm_campaign=launch
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added UTM campaign parameter tracking (source, medium, campaign) for enhanced campaign attribution and analysis
  * Implemented analytics deduplication to eliminate duplicate visitor counts from the same source within 5-minute windows
  * New analytics view showing aggregated visitor metrics and breakdown by UTM campaign source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->