### PR TITLE
fix: 既存セッション再開時にも「設計書を作成する」ボタンを表示

### DIFF
--- a/frontend/src/interview.ts
+++ b/frontend/src/interview.ts
@@ -115,9 +115,11 @@ export async function openSession(sessionId: string, isNew = false): Promise<voi
       return;
     }
 
+    // Show analysis button for existing sessions that are ready
     const userMsgCount = (session.messages || []).filter(m => m.role === 'user').length;
-    const btn = document.getElementById('btn-analyze') as HTMLButtonElement | null;
-    if (btn) btn.disabled = userMsgCount < 3;
+    if (session.status === 'interviewing' && userMsgCount >= 3 && !session.analysis?.facts) {
+      showAnalysisButton();
+    }
   } catch (e: any) {
     showToast(e.message, true);
   } finally {


### PR DESCRIPTION
## 問題

旧コードでインタビュー完了（`[READY_FOR_ANALYSIS]`）まで進んだが分析未実行のセッションを再度開くと、「設計書を作成する」ボタンが表示されなかった。

## 修正

`openSession` で以下の条件を満たす場合に `showAnalysisButton()` を呼び出す:
- `status === 'interviewing'`
- ユーザーメッセージが3件以上
- facts が未生成


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the display logic for the analysis prompt during interview sessions. The analysis trigger now appears at the appropriate moment based on session state and interview progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->