### PR TITLE
fix: PRD/spec を別々の LLM 呼び出しに戻し PRD 品質を復元

### DIFF
--- a/frontend/src/interview.ts
+++ b/frontend/src/interview.ts
@@ -369,7 +369,8 @@ export async function doRunFullPipeline(): Promise<void> {
   const stageLabels: Record<string, string> = {
     facts: t('loading.facts'),
     hypotheses: t('loading.hypotheses'),
-    design: t('loading.prd'),
+    prd: t('loading.prd'),
+    spec: t('loading.spec'),
   };
 
   // Show progress via step nav + loading indicator
@@ -390,8 +391,11 @@ export async function doRunFullPipeline(): Promise<void> {
             renderHypotheses(data.hypotheses || []);
             updateStepNav('hypothesized');
             break;
-          case 'design':
+          case 'prd':
             if (data.prd) renderPRD(data.prd);
+            updateStepNav('prd_generated');
+            break;
+          case 'spec':
             if (data.spec) renderSpec(data.spec);
             updateStepNav('spec_generated');
             activateStep('spec');


### PR DESCRIPTION
## 問題
パイプラインで PRD+spec を1回の LLM 呼び出しに統合した結果、LLM が JSON を二重ラップして PRD が生 JSON ベタ出しになっていた。

## 原因
`DESIGN_SYSTEM` プロンプトが PRD と spec の両方を1つの巨大 JSON で要求 → LLM が `problemDefinition` の値にさらに `\`\`\`json {...}` を入れて返す。

## 修正
- パイプラインを **3ステージ** に変更: facts+hypotheses (1回) → PRD (1回) → spec (1回)
- PRD/spec それぞれ **元の analysis.ts と同じプロンプト** を使用
- facts+hypotheses の1回統合は維持（こちらは問題なし）
- 壊れた3セッションの PRD/spec データを DB から削除済み（再実行で復旧可能）

## テスト
- 162テスト全通過
- TypeScript ビルド成功
- 本番デプロイ済み・稼働確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Interview processing pipeline reorganized: Facts → Hypotheses → PRD → Spec sequence replaces the previous combined Design stage for improved workflow clarity and granular documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->