### PR TITLE
fix: PRD/spec リロード時に空白になる問題を修正

### DIFF
--- a/frontend/src/interview.ts
+++ b/frontend/src/interview.ts
@@ -86,8 +86,8 @@ export async function openSession(sessionId: string, isNew = false): Promise<voi
     if (session.analysis) {
       if (session.analysis.facts) renderFacts(session.analysis.facts.facts ?? []);
       if (session.analysis.hypotheses) renderHypotheses(session.analysis.hypotheses.hypotheses ?? []);
-      if (session.analysis.prd) renderPRD(session.analysis.prd);
-      if (session.analysis.spec) renderSpec(session.analysis.spec);
+      if (session.analysis.prd) renderPRD(session.analysis.prd.prd ?? session.analysis.prd);
+      if (session.analysis.spec) renderSpec(session.analysis.spec.spec ?? session.analysis.spec);
       if (session.analysis.readiness) {
         const rd = session.analysis.readiness;
         renderReadiness(rd.readiness?.categories ?? rd.categories ?? []);
@@ -391,16 +391,20 @@ export async function doRunFullPipeline(): Promise<void> {
             renderHypotheses(data.hypotheses || []);
             updateStepNav('hypothesized');
             break;
-          case 'prd':
-            if (data.prd) renderPRD(data.prd);
+          case 'prd': {
+            const p = data.prd ?? data;
+            renderPRD(p.prd ?? p);
             updateStepNav('prd_generated');
             break;
-          case 'spec':
-            if (data.spec) renderSpec(data.spec);
+          }
+          case 'spec': {
+            const s = data.spec ?? data;
+            renderSpec(s.spec ?? s);
             updateStepNav('spec_generated');
             activateStep('spec');
             initInlineEdit();
             break;
+          }
         }
       },
       onDone: () => {


### PR DESCRIPTION
## 問題
セッションをリロードすると PRD/spec が表示されない。

## 原因
`session.analysis.prd` は `{ prd: { problemDefinition: ... } }` 形式で保存されているが、`renderPRD()` は内側の `{ problemDefinition: ... }` を期待していた。

## 修正
- `.prd ?? data` のフォールバックで両形式に対応
- spec も同様
- パイプラインの onStageData でも同じアンラップを適用

## テスト
- 162テスト全通過
- ブラウザで FMEA セッションの PRD 表示を確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data rendering for PRD and Spec content during interview sessions to handle different payload structures correctly.
  * Resolved inline editing initialization for PRD and Spec data to ensure it activates properly in the pipeline.

* **Improvements**
  * Enhanced pipeline stage handling to robustly process PRD and Spec data with improved fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->