### PR TITLE
docs: Product Hunt バッジを README に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ then generate production-ready PRDs and implementation specs.
 
 [Live Demo](https://deepform.exe.xyz) · [Product Hunt](https://www.producthunt.com/products/deepform) · [GitHub](https://github.com/susumutomita/DeepForm) · [日本語](./README.ja.md)
 
+<a href="https://www.producthunt.com/products/deepform?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-deepform" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1079622&theme=neutral&t=1771207729948" alt="DeepForm - AI depth interviews that turn vague ideas into specs | Product Hunt" width="250" height="54" /></a>
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- README に Product Hunt の Featured バッジを埋め込み（中央揃え）

## Test plan
- [x] lint / typecheck / test 全パス（317 tests）
- [ ] GitHub上でREADMEのバッジ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a Product Hunt badge to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->