### PR TITLE
fix: Analysis 型の prd/spec を PRDData/SpecData に修正してビルドエラーを解消

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -137,8 +137,8 @@ export interface ReadinessData {
 export interface Analysis {
   facts?: FactsData;
   hypotheses?: HypothesesData;
-  prd?: PRD;
-  spec?: Spec;
+  prd?: PRDData;
+  spec?: SpecData;
   readiness?: ReadinessData;
 }
 


### PR DESCRIPTION
## 概要

`make start` / `make build` が TypeScript エラー TS2339 で失敗する問題を修正。

## 変更内容

- `frontend/src/types.ts` の `Analysis` インターフェースで `prd` と `spec` フィールドの型を `PRD`/`Spec` から `PRDData`/`SpecData` に変更
- `interview.ts` で `.prd.prd` / `.spec.spec` のアクセスパターンに対応するラッパー型を正しく参照するように修正

## 原因

`interview.ts:91-92` で `session.analysis.prd.prd` のように `.prd` プロパティにアクセスしているが、`Analysis.prd` が `PRD` 型（`.prd` プロパティを持たない）で定義されていたため TS2339 エラーが発生していた。

## テスト

- lint: warning のみ（既存、今回の変更と無関係）
- typecheck: pass
- test: 18 files, 317 tests all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions to ensure consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->