### PR TITLE
fix: Haiku モデル ID を Gateway 対応版に修正

### DIFF
--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -14,7 +14,7 @@ vi.mock("@hono/node-server/serve-static", () => ({
 
 // LLM モック
 vi.mock("../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック応答" }],

--- a/src/__tests__/middleware/analytics-middleware.test.ts
+++ b/src/__tests__/middleware/analytics-middleware.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],

--- a/src/__tests__/routes/analytics.test.ts
+++ b/src/__tests__/routes/analytics.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],

--- a/src/__tests__/routes/auth.test.ts
+++ b/src/__tests__/routes/auth.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],

--- a/src/__tests__/routes/billing.test.ts
+++ b/src/__tests__/routes/billing.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],

--- a/src/__tests__/routes/campaign-analytics.test.ts
+++ b/src/__tests__/routes/campaign-analytics.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: '{"summary":"テスト分析","patterns":[],"insights":[],"recommendations":[]}' }],

--- a/src/__tests__/routes/edge-cases.test.ts
+++ b/src/__tests__/routes/edge-cases.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],

--- a/src/__tests__/routes/feedback.test.ts
+++ b/src/__tests__/routes/feedback.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM (feedbackルートでは使わないが、app.ts の依存で必要)
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],

--- a/src/__tests__/routes/interview-stream.test.ts
+++ b/src/__tests__/routes/interview-stream.test.ts
@@ -14,7 +14,7 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM (including callClaudeStream for streaming tests)
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],

--- a/src/__tests__/routes/pipeline.test.ts
+++ b/src/__tests__/routes/pipeline.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],

--- a/src/__tests__/routes/prd-edit.test.ts
+++ b/src/__tests__/routes/prd-edit.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn(),
   extractText: vi.fn(),

--- a/src/__tests__/routes/sessions.test.ts
+++ b/src/__tests__/routes/sessions.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20250929",
+  MODEL_FAST: "claude-haiku-4-5-20251001",
   MODEL_SMART: "claude-sonnet-4-5-20250929",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -3,7 +3,7 @@ import http from "node:http";
 import https from "node:https";
 import { Readable } from "node:stream";
 
-export const MODEL_FAST = "claude-haiku-4-5-20250929";
+export const MODEL_FAST = "claude-haiku-4-5-20251001";
 export const MODEL_SMART = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-5-20250929";
 
 const LLM_GATEWAY = "http://169.254.169.254/gateway/llm/anthropic/v1/messages";


### PR DESCRIPTION
## 概要

PR 80 で導入した Haiku モデル ID が exe.dev LLM Gateway で未サポートだったため修正。

## 原因

- 指定: `claude-haiku-4-5-20250929`
- Gateway 対応: `claude-haiku-4-5-20251001`

Gateway の `/v1/models` エンドポイントで確認済み。

## 変更

- `src/llm.ts`: MODEL_FAST のモデル ID を修正
- テスト12ファイル: モック内のモデル ID を同期

## テスト

- [x] 348 テスト全パス
- [x] 実際の LLM リクエストで応答確認済み
