### PR TITLE
feat: Sonnet 4.6 + Opus 4.6 フェーズ別モデル使い分け

### DIFF
--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -14,8 +14,8 @@ vi.mock("@hono/node-server/serve-static", () => ({
 
 // LLM モック
 vi.mock("../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック応答" }],
   }),

--- a/src/__tests__/middleware/analytics-middleware.test.ts
+++ b/src/__tests__/middleware/analytics-middleware.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],
   }),

--- a/src/__tests__/routes/analytics.test.ts
+++ b/src/__tests__/routes/analytics.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],
   }),

--- a/src/__tests__/routes/auth.test.ts
+++ b/src/__tests__/routes/auth.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],
   }),

--- a/src/__tests__/routes/billing.test.ts
+++ b/src/__tests__/routes/billing.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],
   }),

--- a/src/__tests__/routes/campaign-analytics.test.ts
+++ b/src/__tests__/routes/campaign-analytics.test.ts
@@ -13,8 +13,8 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: '{"summary":"テスト分析","patterns":[],"insights":[],"recommendations":[]}' }],
   }),

--- a/src/__tests__/routes/edge-cases.test.ts
+++ b/src/__tests__/routes/edge-cases.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],
   }),

--- a/src/__tests__/routes/feedback.test.ts
+++ b/src/__tests__/routes/feedback.test.ts
@@ -13,8 +13,8 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM (feedbackルートでは使わないが、app.ts の依存で必要)
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],
   }),

--- a/src/__tests__/routes/interview-stream.test.ts
+++ b/src/__tests__/routes/interview-stream.test.ts
@@ -14,8 +14,8 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM (including callClaudeStream for streaming tests)
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],
   }),

--- a/src/__tests__/routes/pipeline.test.ts
+++ b/src/__tests__/routes/pipeline.test.ts
@@ -10,8 +10,8 @@ vi.mock("../../db/index.ts", async () => {
 });
 
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "test" }],
   }),

--- a/src/__tests__/routes/prd-edit.test.ts
+++ b/src/__tests__/routes/prd-edit.test.ts
@@ -13,8 +13,8 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn(),
   extractText: vi.fn(),
 }));

--- a/src/__tests__/routes/sessions.test.ts
+++ b/src/__tests__/routes/sessions.test.ts
@@ -13,8 +13,8 @@ vi.mock("../../db/index.ts", async () => {
 
 // Mock LLM
 vi.mock("../../llm.ts", () => ({
-  MODEL_FAST: "claude-haiku-4-5-20251001",
-  MODEL_SMART: "claude-sonnet-4-5-20250929",
+  MODEL_FAST: "claude-sonnet-4-6",
+  MODEL_SMART: "claude-opus-4-6",
   callClaude: vi.fn().mockResolvedValue({
     content: [{ type: "text", text: "モック LLM レスポンス" }],
   }),

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -3,8 +3,8 @@ import http from "node:http";
 import https from "node:https";
 import { Readable } from "node:stream";
 
-export const MODEL_FAST = "claude-haiku-4-5-20251001";
-export const MODEL_SMART = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-5-20250929";
+export const MODEL_FAST = process.env.ANTHROPIC_MODEL_FAST ?? "claude-sonnet-4-6";
+export const MODEL_SMART = process.env.ANTHROPIC_MODEL ?? "claude-opus-4-6";
 
 const LLM_GATEWAY = "http://169.254.169.254/gateway/llm/anthropic/v1/messages";
 const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";

--- a/src/routes/sessions/analysis.ts
+++ b/src/routes/sessions/analysis.ts
@@ -7,7 +7,7 @@ import { db } from "../../db/index.ts";
 import { saveAnalysisResult } from "../../helpers/analysis-store.ts";
 import { generatePRDMarkdown } from "../../helpers/format.ts";
 import { getOwnedSession, isResponse } from "../../helpers/session-ownership.ts";
-import { callClaude, extractText, MODEL_FAST } from "../../llm.ts";
+import { callClaude, extractText, MODEL_FAST, MODEL_SMART } from "../../llm.ts";
 import type { AppEnv, Session } from "../../types.ts";
 
 const PAYMENT_LINK = "https://buy.stripe.com/test_dRmcMXbrh3Q8ggx8DA48000";
@@ -519,7 +519,7 @@ SIZE RULES (HARD LIMITS):
       [{ role: "user", content: `以下のPRDから実装仕様を生成してください：\n\n${JSON.stringify(prd, null, 2)}` }],
       systemPrompt,
       4096,
-      MODEL_FAST,
+      MODEL_SMART,
     );
     const text = extractText(response);
 
@@ -623,7 +623,7 @@ IMPORTANT: Respond in the SAME LANGUAGE as the input data.
       ],
       systemPrompt,
       8192,
-      MODEL_FAST,
+      MODEL_SMART,
     );
     const text = extractText(response);
 

--- a/src/routes/sessions/pipeline.ts
+++ b/src/routes/sessions/pipeline.ts
@@ -18,7 +18,7 @@ import { db } from "../../db/index.ts";
 import { saveAnalysisResult } from "../../helpers/analysis-store.ts";
 import { generatePRDMarkdown } from "../../helpers/format.ts";
 import { getOwnedSession, isResponse } from "../../helpers/session-ownership.ts";
-import { callClaude, extractText, MODEL_FAST } from "../../llm.ts";
+import { callClaude, extractText, MODEL_FAST, MODEL_SMART } from "../../llm.ts";
 import type { AppEnv, Session } from "../../types.ts";
 
 const PAYMENT_LINK = "https://buy.stripe.com/test_dRmcMXbrh3Q8ggx8DA48000";
@@ -392,7 +392,7 @@ pipelineRoutes.post("/sessions/:id/pipeline", async (c) => {
           ],
           SPEC_SYSTEM,
           4096,
-          MODEL_FAST,
+          MODEL_SMART,
         );
         const specText = extractText(specResp);
         // biome-ignore lint/suspicious/noExplicitAny: dynamic LLM JSON output


### PR DESCRIPTION
## Summary

品質が重要なステップで Opus 4.6 を使い、速度重視のステップは Sonnet 4.6 で処理する構成に変更。

| ステップ | モデル | 理由 |
|---|---|---|
| インタビュー | Sonnet 4.6 | 速度重視、リアルタイム対話 |
| Facts/Hypotheses 抽出 | Sonnet 4.6 | 構造化タスク、速度重視 |
| PRD 編集 | Sonnet 4.6 | 軽量な編集操作 |
| キャンペーン分析 | Sonnet 4.6 | 構造化タスク |
| **PRD 生成** | **Opus 4.6** | 品質重視、最終成果物 |
| **Spec 生成** | **Opus 4.6** | 品質重視、最終成果物 |
| **Readiness チェック** | **Opus 4.6** | 品質重視、レビュー精度 |

## 変更内容

- `src/llm.ts`: MODEL_FAST = `claude-sonnet-4-6`, MODEL_SMART = `claude-opus-4-6`
- `src/routes/sessions/analysis.ts`: Spec 生成・Readiness で MODEL_SMART を使用
- `src/routes/sessions/pipeline.ts`: Spec 生成で MODEL_SMART を使用
- 環境変数 `ANTHROPIC_MODEL_FAST` / `ANTHROPIC_MODEL` で各モデルを上書き可能

## Test plan

- [x] `bun run test` — 全 348 テスト通過
- [x] `bun run lint` + `bun run typecheck` 通過
- [ ] 手動確認: 各ステップが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)