### PR TITLE
fix: インタビュー選択肢が途中で消える問題を修正

### DIFF
--- a/src/__tests__/routes/interview-stream.test.ts
+++ b/src/__tests__/routes/interview-stream.test.ts
@@ -150,7 +150,7 @@ describe("インタビュー ストリーミング API", () => {
       expect(callClaudeStream).toHaveBeenCalledOnce();
     });
 
-    it("[CHOICES] がない場合は空の choices 配列を done に含むこと", async () => {
+    it("[CHOICES] がない場合はフォールバック選択肢を done に含むこと", async () => {
       // Given
       insertSession("sstream-nochoice", "選択肢なし", TEST_USER_ID);
       mockClaudeStream("選択肢のない質問です。");
@@ -165,7 +165,7 @@ describe("インタビュー ストリーミング API", () => {
       const events = parseSSEEvents(await res.text());
       const done = events.find((e) => e.type === "done");
       expect(done).toBeDefined();
-      expect(done.choices).toEqual([]);
+      expect(done.choices.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/__tests__/routes/sessions.test.ts
+++ b/src/__tests__/routes/sessions.test.ts
@@ -998,16 +998,16 @@ describe("セッション API", () => {
       expect(data.reply).not.toContain("[CHOICES]");
     });
 
-    it("[CHOICES] ブロックがない場合は空の choices 配列を返すこと", async () => {
+    it("[CHOICES] ブロックがない場合はフォールバック選択肢を返すこと", async () => {
       // Given: LLM が [CHOICES] ブロックなしの返答を返す
       insertSession("schoice-none", "選択肢なしテスト", TEST_USER_ID);
       vi.mocked(extractText).mockReturnValueOnce("選択肢のない質問です。");
       // When: start
       const res = await authedRequest("/api/sessions/schoice-none/start", { method: "POST" });
-      // Then: 空の choices
+      // Then: フォールバック選択肢が返る
       expect(res.status).toBe(200);
       const data = (await res.json()) as any;
-      expect(data.choices).toEqual([]);
+      expect(data.choices.length).toBeGreaterThan(0);
       expect(data.reply).toBe("選択肢のない質問です。");
     });
   });


### PR DESCRIPTION
## 問題

インタビューの途中から選択肢ボタンが表示されなくなり、UIが止まる。
リトライすると成功する。

## 原因

Haiku モデル（MODEL_FAST）が会話が長くなると `[CHOICES]...[/CHOICES]` のフォーマット指示に従わなくなる。
選択肢が空の場合、フロントエンドはテキスト入力欄のみになり、ユーザーが操作に迷う。

## 修正

### 1. プロンプト強化
- `IMPORTANT` → `CRITICAL FORMAT RULE` に変更
- `Never omit the [CHOICES] block. Every single response must end with it.` を追加

### 2. フォールバック選択肢
LLM が `[CHOICES]` を返さなかった場合、言語別のデフォルト選択肢を表示:
- ja: 「はい、そうです」「いいえ、違います」「もう少し詳しく聞きたいです」「その他」
- en/es/zh: 同等の翻訳

これにより **UI が選択肢なしで止まることがなくなる**。

## テスト
- [x] 357 テスト全パス
- [x] デプロイ済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interview sessions now gracefully provide fallback choice options when no choice block is present in responses, preventing empty option displays and ensuring users always have valid actions to select. Language-specific default options support Japanese, English, Spanish, and Chinese. Fallback handling is applied consistently across all streaming and non-streaming conversation interaction flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->