### PR TITLE
fix: GitHub 保存の 422 エラーを修正 (base_tree にツリー SHA を使用)

### DIFF
--- a/src/__tests__/helpers/github.test.ts
+++ b/src/__tests__/helpers/github.test.ts
@@ -43,6 +43,8 @@ describe("GitHub ヘルパー", () => {
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "base-sha-001" } }));
       // 4. GET /repos/.../git/ref/heads/main (commitFiles)
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "base-sha-001" } }));
+      // 4.5. GET /repos/.../git/commits/base-sha-001 (get tree SHA)
+      mockFetch.mockResolvedValueOnce(mockGhResponse(200, { tree: { sha: "base-tree-sha-001" } }));
       // 5-7. POST /repos/.../git/blobs (3 files)
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-1" }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-2" }));
@@ -87,6 +89,8 @@ describe("GitHub ヘルパー", () => {
       );
       // 3. GET ref
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "base-sha-002" } }));
+      // 3.5. GET commit (get tree SHA)
+      mockFetch.mockResolvedValueOnce(mockGhResponse(200, { tree: { sha: "base-tree-sha-002" } }));
       // 4-6. blobs
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-4" }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-5" }));
@@ -125,6 +129,8 @@ describe("GitHub ヘルパー", () => {
       );
       // 4. GET ref
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "base-sha-003" } }));
+      // 4.5. GET commit (get tree SHA)
+      mockFetch.mockResolvedValueOnce(mockGhResponse(200, { tree: { sha: "base-tree-sha-003" } }));
       // 5-7. blobs
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-7" }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "blob-sha-8" }));
@@ -176,6 +182,8 @@ describe("GitHub ヘルパー", () => {
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "sha" } }));
       // remaining calls for commit
       mockFetch.mockResolvedValueOnce(mockGhResponse(200, { object: { sha: "sha" } }));
+      // GET commit (get tree SHA)
+      mockFetch.mockResolvedValueOnce(mockGhResponse(200, { tree: { sha: "tree-sha" } }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "b1" }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "t1" }));
       mockFetch.mockResolvedValueOnce(mockGhResponse(201, { sha: "c1" }));


### PR DESCRIPTION
## 概要

GitHub 保存機能で 422 (Unprocessable Entity) エラーが発生する問題を修正。

## 原因

`commitFiles` 関数が Git Data API の `POST /repos/{owner}/{repo}/git/trees` に `base_tree` パラメータとしてコミット SHA を渡していたが、API はツリー SHA を期待していた。

## 変更内容

- コミットオブジェクトを取得してツリー SHA を抽出するステップを追加
- `base_tree` にツリー SHA を正しく渡すように修正
- テストのモックを更新（コミットオブジェクト取得の API コールを追加）

## テスト

- 357 tests passed
- lint, typecheck OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the commit creation workflow to properly retrieve and utilize tree references from commit objects.

* **Tests**
  * Added comprehensive test cases to validate tree reference retrieval during file commit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->