### PR TITLE
feat: レディネスチェックのリアルタイムストリーミング

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -185,8 +185,8 @@ export interface PipelineCallbacks {
   onError: (error: string) => void;
 }
 
-export async function runPipeline(sessionId: string, cb: PipelineCallbacks): Promise<void> {
-  const res = await fetch(`/api/sessions/${sessionId}/pipeline`, {
+async function streamSSE(url: string, cb: PipelineCallbacks): Promise<void> {
+  const res = await fetch(url, {
     method: 'POST',
     headers: { 'Accept': 'text/event-stream', 'Content-Type': 'application/json' },
   });
@@ -235,6 +235,14 @@ export async function runPipeline(sessionId: string, cb: PipelineCallbacks): Pro
       }
     }
   }
+}
+
+export function runPipeline(sessionId: string, cb: PipelineCallbacks): Promise<void> {
+  return streamSSE(`/api/sessions/${sessionId}/pipeline`, cb);
+}
+
+export function runReadinessStream(sessionId: string, cb: PipelineCallbacks): Promise<void> {
+  return streamSSE(`/api/sessions/${sessionId}/readiness-stream`, cb);
 }
 
 // GitHub Save

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,49 @@ function getProGate(): ProGateStep {
   return "none";
 }
 
+// ---------------------------------------------------------------------------
+// Readiness system prompt (shared between analysis.ts and pipeline.ts)
+// ---------------------------------------------------------------------------
+export const READINESS_SYSTEM = `You are a production quality review expert. Generate a pre-launch readiness checklist based on ISO/IEC 25010 quality characteristics from the PRD and implementation spec.
+
+IMPORTANT: Respond in the SAME LANGUAGE as the input data.
+
+必ず以下のJSON形式で返してください。JSON以外のテキストは含めないでください。
+
+{
+  "readiness": {
+    "categories": [
+      {
+        "id": "functionalSuitability",
+        "label": "機能適合性",
+        "items": [
+          {
+            "id": "FS-1",
+            "description": "チェック項目の説明",
+            "priority": "must",
+            "rationale": "なぜこのチェックが必要か"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+ルール：
+- ISO/IEC 25010 の8品質特性すべてを網羅すること:
+  1. functionalSuitability（機能適合性）
+  2. performanceEfficiency（性能効率性）
+  3. compatibility（互換性）
+  4. usability（使用性）
+  5. reliability（信頼性）
+  6. security（セキュリティ）
+  7. maintainability（保守性）
+  8. portability（移植性）
+- 各カテゴリに2〜4個の具体的なチェック項目を生成
+- priority は "must"（必須）, "should"（推奨）, "could"（任意）のいずれか
+- PRDの非機能要件と実装仕様に基づいた具体的な項目にすること
+- 抽象的な表現は避け、テスト可能な条件を記述すること`;
+
 /** Returns true if the given step requires Pro under the current PRO_GATE setting. */
 export function requiresProForStep(step: string): boolean {
   const gate = getProGate();

--- a/src/routes/sessions/analysis.ts
+++ b/src/routes/sessions/analysis.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import type { Context } from "hono";
 import { Hono } from "hono";
-import { ANALYSIS_TYPE, requiresProForStep, SESSION_STATUS } from "../../constants.ts";
+import { ANALYSIS_TYPE, READINESS_SYSTEM, requiresProForStep, SESSION_STATUS } from "../../constants.ts";
 import { now } from "../../db/helpers.ts";
 import { db } from "../../db/index.ts";
 import { saveAnalysisResult } from "../../helpers/analysis-store.ts";
@@ -576,45 +576,7 @@ analysisRoutes.post("/sessions/:id/readiness", async (c) => {
       .executeTakeFirst();
     const prd = prdRow ? JSON.parse(prdRow.data) : {};
 
-    const systemPrompt = `You are a production quality review expert. Generate a pre-launch readiness checklist based on ISO/IEC 25010 quality characteristics from the PRD and implementation spec.
-
-IMPORTANT: Respond in the SAME LANGUAGE as the input data.
-
-必ず以下のJSON形式で返してください。JSON以外のテキストは含めないでください。
-
-{
-  "readiness": {
-    "categories": [
-      {
-        "id": "functionalSuitability",
-        "label": "機能適合性",
-        "items": [
-          {
-            "id": "FS-1",
-            "description": "チェック項目の説明",
-            "priority": "must",
-            "rationale": "なぜこのチェックが必要か"
-          }
-        ]
-      }
-    ]
-  }
-}
-
-ルール：
-- ISO/IEC 25010 の8品質特性すべてを網羅すること:
-  1. functionalSuitability（機能適合性）
-  2. performanceEfficiency（性能効率性）
-  3. compatibility（互換性）
-  4. usability（使用性）
-  5. reliability（信頼性）
-  6. security（セキュリティ）
-  7. maintainability（保守性）
-  8. portability（移植性）
-- 各カテゴリに2〜4個の具体的なチェック項目を生成
-- priority は "must"（必須）, "should"（推奨）, "could"（任意）のいずれか
-- PRDの非機能要件と実装仕様に基づいた具体的な項目にすること
-- 抽象的な表現は避け、テスト可能な条件を記述すること`;
+    const systemPrompt = READINESS_SYSTEM;
 
     const response = await callClaude(
       [

--- a/src/routes/sessions/interview.ts
+++ b/src/routes/sessions/interview.ts
@@ -280,7 +280,9 @@ interviewRoutes.post("/sessions/:id/chat", async (c) => {
                 .catch((err) => console.error("Failed to save message:", err));
               const readyForAnalysis = cleanText.includes("[READY_FOR_ANALYSIS]") || turnCount >= 8;
               controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify({ type: "done", readyForAnalysis, turnCount, choices })}\n\n`),
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "done", readyForAnalysis, turnCount, choices: readyForAnalysis ? [] : choices })}\n\n`,
+                ),
               );
               controller.close();
             });
@@ -320,7 +322,7 @@ interviewRoutes.post("/sessions/:id/chat", async (c) => {
       reply: cleanReply.replace("[READY_FOR_ANALYSIS]", "").trim(),
       turnCount,
       readyForAnalysis,
-      choices,
+      choices: readyForAnalysis ? [] : choices,
     });
   } catch (e) {
     if (e instanceof ZodError) return c.json({ error: formatZodError(e) }, 400);


### PR DESCRIPTION
## 概要
- レディネスチェック生成をリアルタイムストリーミング表示に変更
- パイプラインと同じ UX（AI が生成中のテキストが逐次表示される）を実現

## 変更内容
- SSE ストリーミングエンドポイント `POST /sessions/:id/readiness-stream` を追加
- `READINESS_SYSTEM` プロンプトを `constants.ts` に共通化（analysis.ts と pipeline.ts で DRY）
- フロントエンド: `streamSSE` ヘルパーで SSE 消費ロジックを共通化（`runPipeline` / `runReadinessStream` で共用）
- `doRunReadiness` をストリーミング対応に変更（`showStreamingPreview` / `appendStreamingText`）
- 完了時にサイドバー更新 + フィードバック表示

## テスト
- 全 396 テスト通過
- lint / typecheck 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)